### PR TITLE
Move variable declaration outside try/catch block

### DIFF
--- a/app/models/subscriber.js
+++ b/app/models/subscriber.js
@@ -52,8 +52,9 @@ exports = module.exports = function(settings, mongoose, email, logger) {
     var subscriber = this;
 
     if(settings.mailchimp.enabled) {
+      var api;
       try { 
-        var api = new MailChimpAPI(settings.mailchimp.apiKey, { version : '2.0', secure : false });
+        api = new MailChimpAPI(settings.mailchimp.apiKey, { version : '2.0', secure : false });
       } catch (error) {
         logger.error(error.message);
       }


### PR DESCRIPTION
Declaring the variable inside the block and using it afterwards cause problems in gulp postinstall.
More details here: https://jslinterrors.com/a-used-out-of-scope
